### PR TITLE
Implement CsrfLayerBuilder to allow setting the cookie key

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ async fn main() {
 }
 ```
 
+If you already have an encryption key for private cookies, build the layer a different way:
+```rust
+let cookie_key = cookie::Key::generate(); // or from()/derive_from()
+
+let csrf_layer = CsrfLayer::build()
+    .config(CsrfConfig::default())
+    .key(cookie_key)
+    .finish();
+
+let app = Router::new()
+    // ...
+    .layer(csrf_layer);
+```
+
 Get the Hash for the Form to insert into the html for return.
 ```rust
 async fn greet(token: CsrfToken) -> impl IntoResponse {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -18,4 +18,39 @@ impl CsrfLayer {
             key: Key::generate(),
         })
     }
+
+    pub fn build() -> CsrfLayerBuilder {
+        CsrfLayerBuilder::new()
+    }
+}
+
+pub struct CsrfLayerBuilder {
+    config: Option<CsrfConfig>,
+    key: Option<Key>,
+}
+
+impl CsrfLayerBuilder {
+    pub fn new() -> Self {
+        Self {
+            config: None,
+            key: None,
+        }
+    }
+
+    pub fn finish(self) -> Extension<CsrfLayer> {
+        Extension(CsrfLayer {
+            config: self.config.unwrap_or_else(CsrfConfig::default),
+            key: self.key.unwrap_or_else(Key::generate),
+        })
+    }
+
+    pub fn config(mut self, config: CsrfConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    pub fn key(mut self, key: Key) -> Self {
+        self.key = Some(key);
+        self
+    }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -19,17 +19,20 @@ impl CsrfLayer {
         })
     }
 
+    /// Creates a new CsrfLayerBuilder for more flexible setup.
     pub fn build() -> CsrfLayerBuilder {
         CsrfLayerBuilder::new()
     }
 }
 
+/// A builder to construct a CsrfLayer.
 pub struct CsrfLayerBuilder {
     config: Option<CsrfConfig>,
     key: Option<Key>,
 }
 
 impl CsrfLayerBuilder {
+    /// Creates the CsrfLayerBuilder with all fields set to None.
     pub fn new() -> Self {
         Self {
             config: None,
@@ -37,6 +40,9 @@ impl CsrfLayerBuilder {
         }
     }
 
+    /// Creates the CsrfLayer Extension from the currrent config.
+    ///
+    /// If any fields have not been set, this will construct default values for them.
     pub fn finish(self) -> Extension<CsrfLayer> {
         Extension(CsrfLayer {
             config: self.config.unwrap_or_else(CsrfConfig::default),
@@ -44,11 +50,13 @@ impl CsrfLayerBuilder {
         })
     }
 
+    /// Sets the CsrfConfig for the CsrfLayer.
     pub fn config(mut self, config: CsrfConfig) -> Self {
         self.config = Some(config);
         self
     }
 
+    /// Sets the encryption key to use for private cookies.
     pub fn key(mut self, key: Key) -> Self {
         self.key = Some(key);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,5 @@ mod token;
 
 pub use config::CsrfConfig;
 pub use layer::CsrfLayer;
+pub use layer::CsrfLayerBuilder;
 pub use token::CsrfToken;


### PR DESCRIPTION
I noticed that my authenticity tokens weren't working across server restarts because there's a new encryption key generated each time the `CsrfLayer` gets built. To mitigate that, I've added an option to set the key during the build. That way, I can use the same key I already have for other encrypted cookies.

I considered making the `CsrfLayer` fields real-public (instead of just crate-visible), but having the `CsrfLayerBuilder` felt like a less invasive change.

I'm still a novice in both Rust and Axum, so I'll be grateful for any feedback you have :)
